### PR TITLE
Avoid disrupting live-view when keeping it alive

### DIFF
--- a/src/ofxEdsdk.cpp
+++ b/src/ofxEdsdk.cpp
@@ -258,10 +258,6 @@ namespace ofxEdsdk {
 	void Camera::resetLiveView() {
 		lock();
 		if(connected) {
-			if(liveReady) {
-				Eds::EndLiveview(camera);
-				liveReady = false;
-			}
 			Eds::StartLiveview(camera);
 			lastResetTime = ofGetElapsedTimef();
 		}


### PR DESCRIPTION
Experimentation suggests that periodically sending the start signal instead of a start/stop combo is sufficient to keep live-view alive, and avoids the disruption to the stream as the shutter is closed then opened. Tested with EDSDK 2.10 and Canon 7D and 5D Mark II.
