### PR TITLE
Expose internal connected flag as Camera::isConnected()

### DIFF
--- a/src/ofxEdsdk.h
+++ b/src/ofxEdsdk.h
@@ -43,6 +43,8 @@ namespace ofxEdsdk {
         void beginMovieRecording();
         void endMovieRecording();
         bool isMovieNew();
+
+        bool isConnected() { return connected; }
         
     protected:
         void initialize();


### PR DESCRIPTION
Expose the connected flag as a public isConnected() method. A tiny little change that was helpful in allowing a photo booth app to fall back to the webcam when the DSLR was not plugged in.